### PR TITLE
Fixed createHelpers' return functions' parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,6 @@ export const mapMultiRowFields = normalizeNamespace((
 export const createHelpers = ({ getterType, mutationType }) => ({
   [getterType]: getField,
   [mutationType]: updateField,
-  mapFields: fields => mapFields(fields, getterType, mutationType),
-  mapMultiRowFields: paths => mapMultiRowFields(paths, getterType, mutationType),
+  mapFields: (namespace, fields) => mapFields(namespace, fields, getterType, mutationType),
+  mapMultiRowFields: (namespace, paths) => mapMultiRowFields(namespace, paths, getterType, mutationType),
 });


### PR DESCRIPTION
 Functions returned by `createHelpers` can have namespaces defined.