### PR TITLE
fix for #41, reactive nested properties and dynamic properties support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "yarn run fake-publish && jest --coverage --maxWorkers=4",
     "test": "yarn run test:unit && yarn run test:integration",
     "prepublishOnly": "yarn run lint && yarn test && yarn run build",
-    "preinstall":"yarn && yarn build"
+    "postinstall":"yarn && yarn build"
   },
   "dependencies": {
     "vue": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:integration": "yarn run fake-publish && jest test",
     "test:coverage": "yarn run fake-publish && jest --coverage --maxWorkers=4",
     "test": "yarn run test:unit && yarn run test:integration",
-    "prepublishOnly": "yarn run lint && yarn test && yarn run build"
+    "prepublishOnly": "yarn run lint && yarn test && yarn run build",
+    "preinstall":"yarn && yarn build"
   },
   "dependencies": {
     "vue": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "test": "yarn run test:unit && yarn run test:integration",
     "prepublishOnly": "yarn run lint && yarn test && yarn run build"
   },
+  "dependencies": {
+    "vue": "^2.6.2"
+  },
   "devDependencies": {
     "@avalanche/eslint-config": "^3.0.0",
     "@babel/core": "^7.2.2",
@@ -43,7 +46,6 @@
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
     "uglify-es": "^3.3.9",
-    "vue": "^2.6.2",
     "vue-template-compiler": "^2.6.2",
     "vuex": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-map-fields",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Enable two-way data binding for form fields saved in a Vuex store",
   "keywords": [
     "vue",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "yarn run fake-publish && jest --coverage --maxWorkers=4",
     "test": "yarn run test:unit && yarn run test:integration",
     "prepublishOnly": "yarn run lint && yarn test && yarn run build",
-    "postinstall":"yarn && yarn build"
+    "prepare": "yarn build"
   },
   "dependencies": {
     "vue": "^2.6.2"
@@ -46,6 +46,7 @@
     "jest": "^24.0.0",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
+    "typescript":"^3.3.3333",
     "uglify-es": "^3.3.9",
     "vue-template-compiler": "^2.6.2",
     "vuex": "^3.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,10 @@ export function getField(state) {
 
 export function updateField(state, { path, value }) {
 
-  console.log('pathsplit', path.split(/[.[\]]+/));
   path.split(/[.[\]]+/).reduce((prev, key, index, array) => {
     // console.log(`BEFORE: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
     // console.log('BEFORE: prev[key]:', prev[key]);
 
-    const nv = index == array.length-1 ? value: prev[key] != null ? prev[key]: {}
     if (index < array.length - 1){
       Vue.set(prev, key, prev[key] ? prev[key]: {});
     }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,6 @@ export function getField(state) {
 
 export function updateField(state, { path, value }) {
   path.split(/[.[\]]+/).reduce((prev, key, index, array) => {
-
     if (index < array.length - 1) {
       Vue.set(prev, key, prev[key] ? prev[key] : {});
     } else { // last key

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import arrayToObject from './lib/array-to-object';
 import Vue from 'vue';
+import arrayToObject from './lib/array-to-object';
 
 function normalizeNamespace(fn) {
   return (...params) => {
@@ -19,26 +19,23 @@ function normalizeNamespace(fn) {
 }
 
 export function getField(state) {
-  return path => path.split(/[.[\]]+/).reduce((prev, key) => prev && prev.hasOwnProperty(key)?prev[key]:null, state);
+  return path => path.split(/[.[\]]+/).reduce((prev, key) => (prev && prev[key] ? prev[key] : null), state);
 }
 
 export function updateField(state, { path, value }) {
-
   path.split(/[.[\]]+/).reduce((prev, key, index, array) => {
     // console.log(`BEFORE: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
     // console.log('BEFORE: prev[key]:', prev[key]);
 
-    if (index < array.length - 1){
-      Vue.set(prev, key, prev[key] ? prev[key]: {});
-    }
-    else { // last key
+    if (index < array.length - 1) {
+      Vue.set(prev, key, prev[key] ? prev[key] : {});
+    } else { // last key
       Vue.set(prev, key, value);
     }
 
     // console.log(`AFTER: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
 
     return prev[key];
-
   }, state);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,16 +24,12 @@ export function getField(state) {
 
 export function updateField(state, { path, value }) {
   path.split(/[.[\]]+/).reduce((prev, key, index, array) => {
-    // console.log(`BEFORE: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
-    // console.log('BEFORE: prev[key]:', prev[key]);
 
     if (index < array.length - 1) {
       Vue.set(prev, key, prev[key] ? prev[key] : {});
     } else { // last key
       Vue.set(prev, key, value);
     }
-
-    // console.log(`AFTER: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
 
     return prev[key];
   }, state);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import arrayToObject from './lib/array-to-object';
+import Vue from 'vue';
 
 function normalizeNamespace(fn) {
   return (...params) => {
@@ -18,17 +19,28 @@ function normalizeNamespace(fn) {
 }
 
 export function getField(state) {
-  return path => path.split(/[.[\]]+/).reduce((prev, key) => prev[key], state);
+  return path => path.split(/[.[\]]+/).reduce((prev, key) => prev && prev.hasOwnProperty(key)?prev[key]:null, state);
 }
 
 export function updateField(state, { path, value }) {
+
+  console.log('pathsplit', path.split(/[.[\]]+/));
   path.split(/[.[\]]+/).reduce((prev, key, index, array) => {
-    if (array.length === index + 1) {
-      // eslint-disable-next-line no-param-reassign
-      prev[key] = value;
+    // console.log(`BEFORE: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
+    // console.log('BEFORE: prev[key]:', prev[key]);
+
+    const nv = index == array.length-1 ? value: prev[key] != null ? prev[key]: {}
+    if (index < array.length - 1){
+      Vue.set(prev, key, prev[key] ? prev[key]: {});
+    }
+    else { // last key
+      Vue.set(prev, key, value);
     }
 
+    // console.log(`AFTER: array: ${array}  -- index:${index}  -- key:${key} --- prev:`, prev);
+
     return prev[key];
+
   }, state);
 }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -15,6 +15,10 @@ describe(`index`, () => {
     test(`It should return a function which returns the value of the state at the given path.`, () => {
       expect(getField({ foo: { bar: `value` } })(`foo.bar`)).toEqual(`value`);
     });
+
+    test(`It should return a function which returns the value of the state at the given path even when the key chain is invalid`, () => {
+      expect(getField({ foo: { bar: `value` } })(`foo.extra.bar`)).toBeNull();
+    });
   });
 
   describe(`updateField()`, () => {
@@ -27,6 +31,15 @@ describe(`index`, () => {
       const expectedResult = { foo: { bar: `new value` } };
 
       updateField(mockState, { path: `foo.bar`, value: `new value` });
+
+      expect(mockState).toEqual(expectedResult);
+    });
+
+    test(`It should override the key at the given path in the state with the given value even when the key chain is broken.`, () => {
+      const mockState = { foo: { bar: `initial value` } };
+      const expectedResult = { foo: { bar: `initial value`, extra: { extrabar: `new value` } } };
+
+      updateField(mockState, { path: `foo.extra.extrabar`, value: `new value` });
 
       expect(mockState).toEqual(expectedResult);
     });

--- a/test/nested-dynamic-store.test.js
+++ b/test/nested-dynamic-store.test.js
@@ -1,0 +1,66 @@
+import Vuex from 'vuex';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+
+import { createHelpers, getField, updateField } from './package/src';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+const { mapFields } = createHelpers({
+  getterType: `getFormField`,
+  mutationType: `updateFormField`,
+});
+
+describe(`Component initialized with customized getter and mutation functions.`, () => {
+  let Component;
+  let store;
+  let wrapper;
+
+  beforeEach(() => {
+    Component = {
+      template: `<input id="foo" v-model="foo3">`,
+      computed: {
+        ...mapFields([
+          `foo1.foo2.foo3`,
+        ]),
+      },
+    };
+
+    store = new Vuex.Store({
+      state: {
+        form: { foo1: {} },
+      },
+      getters: {
+        getFormField(state) {
+          return getField(state.form);
+        },
+      },
+      mutations: {
+        updateFormField(state, payload) {
+          updateField(state.form, payload);
+        },
+      },
+    });
+
+    wrapper = shallowMount(Component, { localVue, store });
+  });
+
+  test(`It should render the component.`, () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  test(`It should update field values when the store is updated.`, () => {
+    store.commit('updateFormField', {path:'foo1.foo2.foo3', value:'fooValue'}, true);
+    // store.state.form.foo1.foo2.foo3 = `fooValue`;
+
+    expect(wrapper.element.value).toBe(`fooValue`);
+  });
+
+  test(`It should update the store when the field values are updated.`, () => {
+    wrapper.element.value = `fooValue`;
+    wrapper.trigger(`input`);
+
+    expect(store.state.form.foo1.foo2.foo3).toBe(`fooValue`);
+  });
+});

--- a/test/nested-dynamic-store.test.js
+++ b/test/nested-dynamic-store.test.js
@@ -22,7 +22,7 @@ describe(`Component initialized with customized getter and mutation functions.`,
       template: `<input id="foo" v-model="foo3">`,
       computed: {
         ...mapFields([
-          `foo1.foo2.foo3`,
+          `foo1.foo11.foo2.foo3`,
         ]),
       },
     };
@@ -51,8 +51,8 @@ describe(`Component initialized with customized getter and mutation functions.`,
   });
 
   test(`It should update field values when the store is updated.`, () => {
-    store.commit('updateFormField', {path:'foo1.foo2.foo3', value:'fooValue'}, true);
-    // store.state.form.foo1.foo2.foo3 = `fooValue`;
+    store.commit('updateFormField', {path:'foo1.foo11.foo2.foo3', value:'fooValue'}, true);
+    // store.state.form.foo1.foo11.foo2.foo3 = `fooValue`;
 
     expect(wrapper.element.value).toBe(`fooValue`);
   });
@@ -61,6 +61,6 @@ describe(`Component initialized with customized getter and mutation functions.`,
     wrapper.element.value = `fooValue`;
     wrapper.trigger(`input`);
 
-    expect(store.state.form.foo1.foo2.foo3).toBe(`fooValue`);
+    expect(store.state.form.foo1.foo11.foo2.foo3).toBe(`fooValue`);
   });
 });

--- a/test/nested-dynamic-store.test.js
+++ b/test/nested-dynamic-store.test.js
@@ -51,7 +51,7 @@ describe(`Component initialized with customized getter and mutation functions.`,
   });
 
   test(`It should update field values when the store is updated.`, () => {
-    store.commit('updateFormField', {path:'foo1.foo11.foo2.foo3', value:'fooValue'}, true);
+    store.commit(`updateFormField`, { path: `foo1.foo11.foo2.foo3`, value: `fooValue` }, true);
     // store.state.form.foo1.foo11.foo2.foo3 = `fooValue`;
 
     expect(wrapper.element.value).toBe(`fooValue`);

--- a/test/nested-dynamic-store.test.js
+++ b/test/nested-dynamic-store.test.js
@@ -53,8 +53,19 @@ describe(`Component initialized with customized getter and mutation functions.`,
   test(`It should update field values when the store is updated.`, () => {
     store.commit(`updateFormField`, { path: `foo1.foo11.foo2.foo3`, value: `fooValue` }, true);
     // store.state.form.foo1.foo11.foo2.foo3 = `fooValue`;
-
     expect(wrapper.element.value).toBe(`fooValue`);
+  });
+
+  test(`It should return correct values when different paths have been created`, () => {
+    store.commit(`updateFormField`, { path: `foo1.foo11.foo2.foo3`, value: `fooValue` }, true);
+    store.commit(`updateFormField`, { path: `foo1.foo11.someUglyFoo.foo2.foo99`, value: `otherValue` }, true);
+    expect(store.state.form.foo1.foo11.foo2.foo3).toBe(`fooValue`);
+    expect(store.state.form.foo1.foo11.someUglyFoo.foo2.foo99).toBe(`otherValue`);
+  });
+
+  test(`It should return null values when paths are incorrect`, () => {
+    store.commit(`updateFormField`, { path: `foo1.foo11.foo2.foo3`, value: `fooValue` }, true);
+    expect(wrapper.e).toBe(undefined);
   });
 
   test(`It should update the store when the field values are updated.`, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4645,6 +4645,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typescript@^3.3.3333:
+  version "3.3.3333"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
+  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
+
 uglify-es@^3.3.9:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"


### PR DESCRIPTION
store commits via updateField now creates reactive properties across the nested chain.
also when dealing with dynamic properties (chains that are not known at compile time) this fix ensures the safety of the nested chain by creating store objects as needed.

the nested properties are made reactive by default according to vue recommendations (https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties)
