### PR TITLE
Support getters returning functions (Getters with params)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export const mapFields = normalizeNamespace((namespace, fields, getterType, muta
       set(value) {
         const isFunctionGetter = typeof path === `function`;
         const param = isFunctionGetter ? path.call(this) : null;
-        const values = { path, value };
+        const values = { path: isFunctionGetter ? path.name : path, value };
         if (param) {
           values.param = param;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,7 @@ export const mapFields = normalizeNamespace((namespace, fields, getterType, muta
         const isFunctionGetter = typeof path === `function`;
         if (isFunctionGetter) {
           const param = path.call(this);
-          const getter = this.$store.getters(param);
-          return typeof getter === `function`
-            ? getter(path.name)
-            : getter;
+          return this.$store.getters[getterType](param)(path.name);
         }
 
         return this.$store.getters[getterType](path);


### PR DESCRIPTION
I've come across this library a few weeks ago and has been using it without any issues. However, the application I work on has a lot of complex data being managed in the store. This involves

- Handling deeply nested data, using `normalizr` to normalize it
- Splitting up state based on `id`, to speed up load process and cache data. 

When the latter came in, I had realized this only supported regular getters, while I was used to passing ids to getters to get that portion of the state, but based on the item `id`

Since then I've spent some time wondering which one was the best choice for this library to handle getter functions with params. 

In vuex, map getters does not support passing in params, so the most common solution is to map the getter and use it in a method or computed property. We can't do that here, because what this does is adding getter and setter properties to all computed properties and we can't re-map that.

So the solution I've come across this is using object notation with function property, returning the param we want to pass in, if we ever needed to use multiple params, we'd pass in an object and maybe spread it on out custom getter.

Here's the usage example

```javascript
getDetails: state => id => { 
   const profile = state.clientProfiles[id];
   return getField(profile.details);
}

setDetails: (state, { param: id, ...field }) => {
   const profile = state.clientProfiles[id];
   return updateField(profile.details, field);
}
```
 ```javascript
 ...mapMultiRowFields("Store", {
   applicants() {
     return this.profileId;
   }
 })
```

Let me know if you're ok with this approach and if this makes sense so I go further and add some tests to it. 
