### PR TITLE
multiRow ability to handle with Object instead array only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,11 +69,11 @@ export const mapMultiRowFields = normalizeNamespace((
     entries[key] = {
       get() {
         const store = this.$store;
-        const rows = store.getters[getterType](path);
+        const rows = Object.entries(store.getters[getterType](path));
 
         return rows
-          .map((fieldsObject, index) => Object.keys(fieldsObject).reduce((prev, fieldKey) => {
-            const fieldPath = `${path}[${index}].${fieldKey}`;
+          .map((fieldsObject, index) => Object.keys(fieldsObject[1]).reduce((prev, fieldKey) => {
+            const fieldPath = `${path}[${fieldsObject[0]}].${fieldKey}`;
 
             return Object.defineProperty(prev, fieldKey, {
               get() {


### PR DESCRIPTION
Once object properties are iterable, we have possibility to store our "rows" inside an object. Not only in arrays. This is useful when you are building a generic module as described [here](https://markus.oberlehner.net/blog/generic-content-vuex-modules/). 

```javascript
const state = {
  byId: {
    "/rooms/1": {
        name: "Nice room"
    },
    "/rooms/2": {
        name: "Nice room 2"
    },
  },
  allIds: ["/rooms/1", "/rooms/2"],
};
```
As we can iterate over byId as an array inside our template
```javascript
 ...mapMultiRowFields('rooms', ['byId']),
```
Template:
```javascript
<div v-for="(room, index) in byId">
```
Makes sense we able to enable Two-way for objects inside 'byId'.
```javascript
<input v-model="room.name">
```
For this to work, we just need a little change into fieldPath. This is what my pull are about.

Best regards