### PR TITLE
Allow enumeration of object properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,7 @@ export const mapMultiRowFields = normalizeNamespace((
             const fieldPath = `${path}[${fieldsObject[0]}].${fieldKey}`;
 
             return Object.defineProperty(prev, fieldKey, {
+              enumerable: true,
               get() {
                 return store.getters[getterType](fieldPath);
               },


### PR DESCRIPTION
Vuex's reactive object allow us to enumerate its properties, but objects returned by `mapMultiRowFields` do not. I want to be able to shallow copy the object but cannot without `enumerable: true` set.